### PR TITLE
Update Dockerfile to cope with Persistent Storage deployment on Origin or elsewhere.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,13 @@ RUN chown -R jenkins:jenkins $JENKINS_HOME/
 ENV JAVA_OPTS="-Djava.util.logging.config.file=/var/jenkins_home/log.properties -Ddocker.host=unix:/var/run/docker.sock"
 
 EXPOSE 8000
+# Date : 23 Feb 2016
+# Principle, clone the /var/jenkins_home/ area into a ref area
+# Allowing to map this area to a persistent storage :
+#   When mapped to an empty area, then fill it with the mandatory files from the ref area.
+#
+RUN cp -r /var/jenkins_home/ /var/ref_jenkins_home
+RUN rm -rf /var/jenkins_home/*
+RUN sed -i '2iif [ ! -f "/var/jenkins_home/config.xml" ]; then cp -r /var/ref_jenkins_home/* /var/jenkins_home/;fi' /root/start.sh
 
 ENTRYPOINT ["/root/start.sh"]


### PR DESCRIPTION
In aim to keep the Jenkins jobs & history, we need to keep the jenkins_home persistent.
Here the Dockerfile modified is making a copy of the original jenkins_home in a reference  place, and it adds the copy from this ref to the original place, if this one is detected empty when the start.sh is run (start of the container)
I have validated this on my own instances (3 clusters)
I have also the updated CD-Pipeline to get the PVC.
This change is backward compatibile and work well if the attachment is not done.
JMarc